### PR TITLE
Loosen the Plug version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule CrashPlug.Mixfile do
   defp deps do
     [
       {:cowboy, "~> 1.0"},
-      {:plug, "~> 1.3.5"}
+      {:plug, "~> 1.3"}
     ]
   end
 


### PR DESCRIPTION
Using `~> 1.3.5` causes a conflict is there's another dependency that wants something `1.4.0` or newer. By setting it to `~> 1.3`, it'll allow anything up to (but not including) `2.0.0`.

If `1.3.4` actually won't work for some reason, then I think the options would be either `~> 1.4` or `~> 1.3.5 or ~>1.4`.